### PR TITLE
Update README with path planner explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
-# hashClass
+Okay, little buddy, imagine you have a big piece of graph paper and some toy rocks, and you want to draw a line from your red toy car to your green toy castle without bumping into the rocks. Here’s how the “computer game” you showed works:
+
+
+A Big Drawing Board
+
+There’s a big rectangle (the canvas) where everything happens, just like your playmat.
+
+Grid Squares
+
+The playmat is covered in lots of little squares (the grid). You can make the squares bigger or smaller with the number box.
+
+Red Car and Green Castle
+
+A red circle is your car (start), and a green circle is your castle (goal). You can drag them around with your finger (or mouse) to new places.
+
+Random Rocks
+
+Black circles are rocks. When you press “Randomize Obstacles,” the computer scatters eight rocks in new spots so your car can’t go through them.
+
+Finding a Path
+
+When you press “Run,” the computer looks at the grid and figures out a way from the red car to the green castle that doesn’t crash into any rocks.
+
+Making the Path Pretty
+
+First, it draws a simple straight-step path—like hopping from square to square.
+
+Then it uses different “magic crayons” (algorithms) to round corners, smooth out the line, or even run a second check to make it extra neat.
+
+Choosing Your Magic Crayon
+
+There’s a dropdown menu where you pick how fancy you want the path to look:
+
+“A* + Earcut” is the basic crayon.
+
+“+ Bézier” adds round curves.
+
+“+ Chaikin” makes it even softer, like drawing with chalk.
+
+And “Full Pipeline” does all the magic steps in order.
+
+Seeing What’s Happening
+
+The little gray box (debug) tells you how many squares it looked at, how many bumps it smoothed, and other fun numbers so you know it’s working.
+
+So every time you press “Run,” it’s like asking the computer: “Hey, what’s the best way to drive my red car across these squares without hitting the rocks?” And it draws you that neat, colorful path!


### PR DESCRIPTION
## Summary
- replace README with explanation of how the path-planning demo works in simple terms

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684487aa195c8330bfa84050cd688cc0